### PR TITLE
Enable operation on Linux and Mac

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.inventivetalent</groupId>
     <artifactId>bossbarapi</artifactId>
-    <version>2.4.1</version>
+    <version>2.4.2</version>
     <name>BossBarAPI</name>
     <build>
         <finalName>BossBarAPI_v${project.version}</finalName>

--- a/src/org/inventivetalent/bossbar/reflection/Reflection.java
+++ b/src/org/inventivetalent/bossbar/reflection/Reflection.java
@@ -9,12 +9,12 @@ public abstract class Reflection {
 
 	public static String getVersion() {
 		String name = Bukkit.getServer().getClass().getPackage().getName();
-		String version = name.substring(name.lastIndexOf('.') + 1) + ".";
+		String version = name.substring(name.lastIndexOf('.') + 1);
 		return version;
 	}
 
 	public static Class<?> getNMSClass(String className) {
-		String fullName = "net.minecraft.server." + getVersion() + className;
+		String fullName = "net.minecraft.server." + getVersion() + "." + className;
 		Class<?> clazz = null;
 		try {
 			clazz = Class.forName(fullName);
@@ -25,13 +25,13 @@ public abstract class Reflection {
 	}
 
 	public static Class<?> getNMSClassWithException(String className) throws Exception {
-		String fullName = "net.minecraft.server." + getVersion() + className;
+		String fullName = "net.minecraft.server." + getVersion() + "." + className;
 		Class<?> clazz = Class.forName(fullName);
 		return clazz;
 	}
 
 	public static Class<?> getOBCClass(String className) {
-		String fullName = "org.bukkit.craftbukkit." + getVersion() + className;
+		String fullName = "org.bukkit.craftbukkit." + getVersion() + "." + className;
 		Class<?> clazz = null;
 		try {
 			clazz = Class.forName(fullName);


### PR DESCRIPTION
**Error:**

On Mac and Linux the plugin does not load, throwing an error:

```
[08:13:41 INFO]: [ReflectionHelper] Generating dynamic constant...
[08:13:41 INFO]: [ReflectionHelper] Version is UNKNOWN (-1)
[08:13:41 ERROR]: Could not load 'plugins/BossBarAPI_v2.4.1.jar' in folder 'plugins'
org.bukkit.plugin.InvalidPluginException: java.lang.ExceptionInInitializerError
...
Caused by: java.lang.RuntimeException: java.lang.ClassNotFoundException: Could not resolve class for [ResolverQuery{name='org.bukkit.craftbukkit.UNKNOWN.entity.CraftEntity', types=[]}]
...
Caused by: java.lang.ClassNotFoundException: Could not resolve class for [ResolverQuery{name='org.bukkit.craftbukkit.UNKNOWN.entity.CraftEntity', types=[]}]
```

**The Cause:**

The trailing "." in the path returned by `getVersion()` is ignored on Windows, but causes a failure on Mac and Linux. 

**Fix:**

This patch removes the trailing "." from `getVersion()` and adds it when adding the return value of `getVersion()` to classnames.